### PR TITLE
Fix crawler start_crawl argument handling

### DIFF
--- a/crawler/crawler.py
+++ b/crawler/crawler.py
@@ -48,12 +48,16 @@ class WebCrawler:
         self.rp.read()
         # ——————————————
 
-    def start_crawl(self):
+    def start_crawl(self, max_pages, confirm: bool = False):
         """
         Clear any previous state and begin crawling from the start_url.
+
+        Args:
+            max_pages (int): Maximum number of pages to visit.
+            confirm (bool): Override robots.txt restrictions.
         """
         self.visited.clear()
-        self.crawl(self.start_url)
+        self.crawl(self.start_url, max_pages, confirm=confirm)
 
     def crawl(self, url: str, max_pages: int, confirm: bool = False) -> None:
         """


### PR DESCRIPTION
## Summary
- allow `start_crawl` to accept `max_pages` and `confirm`
- pass these parameters to the `crawl` method

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_686fa3328260832583963c91bde7c394